### PR TITLE
Use pushInsteadOf to always git push with ssh (without requiring me to git pull with ssh)

### DIFF
--- a/gitconfig.sh
+++ b/gitconfig.sh
@@ -13,5 +13,5 @@ export GIT_DUET_GLOBAL=1
 export GIT_DUET_ROTATE_AUTHOR=1
 find ~/workspace/ -type d -name '.git' -exec sh -c 'cd {} && cd .. && git init' \;
 
-git config --global url."git@github.com:".insteadOf "https://github.com/"
+git config --global url."git@github.com:".pushInsteadOf "https://github.com/"
 


### PR DESCRIPTION
This is preferred over always using ssh because this allows an
engineer to pull using https (which they often do with open source
repositories), while always using their ssh key to push (in the case of
both open source and private repositories). This also maintains the
functionality of pulling with ssh if the repository was cloned with the
ssh url in the case of private repositories.

Relevant [link](http://engineering.pivotal.io/post/git-push-instead-of/) that explains this better. Thanks Gabe!