### PR TITLE
Fix ssh agent forwarding

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -6,10 +6,13 @@ fi
 
 [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
 
-# always use the same ssh-agent
-# shamelessly lifted from https://unix.stackexchange.com/a/132117/385935
-export SSH_AUTH_SOCK=~/.ssh/ssh-agent.$HOSTNAME.sock
-ssh-add -l 2>/dev/null >/dev/null
-if [ $? -ge 2 ]; then
-  ssh-agent -a "$SSH_AUTH_SOCK" >/dev/null
+# Only set the ssh_auth_sock when not using ssh agent forwarding
+if [[ -z "${SSH_AUTH_SOCK}" ]]; then
+      # always use the same ssh-agent
+      # shamelessly lifted from https://unix.stackexchange.com/a/132117/385935
+      export SSH_AUTH_SOCK=~/.ssh/ssh-agent.$HOSTNAME.sock
+      ssh-add -l 2>/dev/null >/dev/null
+      if [ $? -ge 2 ]; then
+        ssh-agent -a "$SSH_AUTH_SOCK" >/dev/null
+      fi
 fi


### PR DESCRIPTION
- ssh agent forwarding allows an engineer to forward their local agent
to the server so they can use a locally loaded key e.g ssh -A
- this is discovered by checking if the SSH_AUTH_SOCK environment
variable is set. If it is set when the .bash_profile is loaded, then
that probably means the user ssh'd onto the machine with a ssh agent
forwarded and we shouldn't override that agent with our own. If it is
not set, then it is probably safe to set it to the single SSH_AUTH_SOCK.
Best of both worlds.