### PR TITLE
Add additional git aliases

### DIFF
--- a/gitconfig.sh
+++ b/gitconfig.sh
@@ -15,3 +15,19 @@ find ~/workspace/ -type d -name '.git' -exec sh -c 'cd {} && cd .. && git init' 
 
 git config --global url."git@github.com:".pushInsteadOf "https://github.com/"
 
+
+# git aliases
+git config --global alias.last 'log -1 HEAD'
+
+git config --global alias.ci 'duet-commit -v'
+git config --global alias.cira 'git duet-commit -v --amend --reset-author'
+git config --global alias.co 'checkout'
+git config --global alias.di 'diff'
+git config --global alias.st 'status'
+
+git config --global alias.llog 'log --date=local'
+git config --global alias.flog 'log --pretty=fuller --decorate'
+git config --global alias.lg "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative"
+git config --global alias.lol 'log --graph --decorate --oneline'
+git config --global alias.lola 'log --graph --decorate --oneline --all'
+git config --global alias.blog 'log origin/master... --left-right'


### PR DESCRIPTION
Add some convenience aliases for git commands such as

`git ci` for `git duet-commit -v`
`git cira` for `git duet-commit -v --reset-author --amend`
etc..