### PR TITLE
This adds the ability to use the arrow keys to navigate bash history

### DIFF
--- a/.inputrc
+++ b/.inputrc
@@ -1,0 +1,6 @@
+$include /etc/inputrc
+
+## arrow up
+"\e[A":history-search-backward
+## arrow down
+"\e[B":history-search-forward

--- a/configure.sh
+++ b/configure.sh
@@ -19,6 +19,7 @@ wget -O - https://raw.githubusercontent.com/luan/tmuxfiles/master/install | bash
 # install bash profile
 rm ~/.bash_aliases ~/.bash_logout ~/.bash_profile ~/.bashrc ~/.profile
 ln -s $(pwd)/.bash* ~/
+ln -s $(pwd)/.inputrc ~/
 ln -s $(pwd)/.profile ~/
 
 # fly aliases


### PR DESCRIPTION
This PR adds the ability to use 'up arrow' when a command is partially written to cycle through all commands in bash history that start with the given prefix.