### PR TITLE
Add xclip to devenv

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -24,3 +24,6 @@ complete -F __start_kubectl kw
 alias reload="source ~/.bash_profile"
 
 alias vpn="sudo openconnect --no-dtls --protocol=gp gp-den2.vmware.com"
+
+alias pbcopy="xclip -sel clip"
+alias pbpaste="xclip -o -sel clip"

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@ apt-get install -yq \
   tmux \
   tree \
   wget \
+  xclip \
   zlib1g-dev \
 
 sudo ln -s $(which fdfind) /usr/bin/fd


### PR DESCRIPTION
Now you can use xclip to copy commands, files, etc to your system clipboard! :partying_face: 

To use enable X11 forwarding on SSH/gcloud (use -Y)

Example 1) Copy file contents from devenv to your system clipboard: `xclip -sel clip <file> `
Example 2) Copy a command from devenv to your system clipboard: `<command> | xclip -sel clip`
